### PR TITLE
Added multi-stage build to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM maven:3-jdk-8-onbuild
+FROM maven:3-jdk-8-onbuild as builder
 
 # Install built package
 RUN tar -xvzf target/grib2json-*.gz
-RUN cp grib2json-*/bin/* /usr/bin
-RUN cp grib2json-*/lib/* /usr/lib
+RUN mkdir -p /output/bin/ /output/lib/
+RUN cp grib2json-*/bin/* /output/bin/
+RUN cp grib2json-*/lib/* /output/lib/
+
+FROM openjdk:8-jre-alpine
+COPY --from=builder /output/bin/ /usr/bin
+COPY --from=builder /output/lib/ /usr/lib
 
 CMD grib2json $ARGS
-


### PR DESCRIPTION
The current Dockerfile produces the final image using the whole Maven image which is more than 700MB in size. The multi-stage Dockerfile copies only the files required to run grib2json in an Alpine based OpenJRE image reducing the size of the final image to just 100MB.